### PR TITLE
Fix for overflow of long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ final lyrics = '''
     lyrics: _lyrics,
     textStyle: textStyle,
     chordStyle: chordStyle,
+    widgetPadding: 50,
     onTapChord: (String chord) {
       print('pressed chord: $chord');
     },

--- a/lib/src/chord_parser.dart
+++ b/lib/src/chord_parser.dart
@@ -13,9 +13,65 @@ class ChordProcessor {
     required String text,
     required TextStyle lyricsStyle,
     required chordStyle,
+    required widgetPadding,
     int transposeIncrement = 0,
   }) {
     final lines = text.split('\n');
+
+    bool _chordHasStartedOuter = false;
+    String _currentCharacters = '';
+    int _lastSpace = 0;
+    String _currentLine = '';
+    String _character = '';
+    double _media = MediaQuery.of(context).size.width;
+    int _characterIndex = 0;
+
+    //list to store our updated lines without overflows
+    final _newLines = <String>[];
+
+    //loop through the lines
+    for (var i = 0; i < lines.length; i++) {
+      _currentLine = lines[i];
+
+      //check if we have a long line
+      if (textWidth(_currentLine, lyricsStyle) >= _media) {
+        
+        //work our way through the line and split when we need to
+        for (var j = 0; j < _currentLine.length; j++) {
+          _character = _currentLine[j];
+          if (_character == '[')
+            _chordHasStartedOuter = true;
+          else if (_character == ']')
+            _chordHasStartedOuter = false;
+          else if (_chordHasStartedOuter == true)
+            ;
+          else {
+            _currentCharacters += _character;
+            if (_character == ' ') {
+              //use this marker to only split where there are spaces
+              _lastSpace = j;
+            }
+
+            //This is the point where we need to split
+            //I've added widgetPadding as a parameter to be passed from the build function
+            //It is intended to allow for padding in the widget when comparing it to screen width
+            //I had to add a little extra (about 10) to stop overflow.
+            if (textWidth(_currentCharacters, lyricsStyle) + widgetPadding >= _media) {
+              _newLines.add(lines[i].substring(_characterIndex, _lastSpace).trim());
+              _currentCharacters = '';
+              _characterIndex = _lastSpace;
+            }
+          }
+        }
+        //add the rest of the long line
+        _newLines.add(lines[i].substring(_characterIndex, lines[i].length).trim());
+        ;
+      } else {
+        //otherwise just add the regular line
+        _newLines.add(lines[i].trim());
+      }
+    }
+    ;
     List<ChordLyricsLine> _chordLyricsLines =
         lines.map<ChordLyricsLine>((line) {
       ChordLyricsLine _chordLyricsLine = ChordLyricsLine([], '');

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -27,6 +27,7 @@ class LyricsRenderer extends StatefulWidget {
     required this.chordStyle,
     required this.onTapChord,
     this.showChord = true,
+    this.widgetPadding = 0,
     this.transposeIncrement = 0,
     this.scrollSpeed = 0,
   }) : super(key: key);
@@ -45,6 +46,7 @@ class _LyricsRendererState extends State<LyricsRenderer> {
       text: widget.lyrics,
       lyricsStyle: widget.textStyle,
       chordStyle: widget.chordStyle,
+      widgetPadding: widget.widgetPadding,
       transposeIncrement: widget.transposeIncrement,
     );
     if (chordLyricsDocument.chordLyricsLines.isEmpty) return Container();

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -8,6 +8,9 @@ class LyricsRenderer extends StatefulWidget {
   final TextStyle chordStyle;
   final bool showChord;
   final Function onTapChord;
+  
+  //To help stop overflow
+  final int widgetPadding;
 
   /// Transpose Increment for the Chords,
   /// defaule value is 0, which means no transpose is applied


### PR DESCRIPTION
This is intended to make long lines wrap. Both the lyrics and chords will wrap if they are going to extend over the edge of a screen. This will also work if a user rotates the screen.

Basically there is some processing done on long lines to split them if they are larger than the screen width. There is an addition property of padding to take into account the width of the widget that is displaying the lyrics. Not sure if there is a better way to do this but it worked for me.

I'm not a pro at this so please review and fix any errors :)