### PR TITLE
Allow external ScrollController and FIX inconsistent speed behavior

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,28 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -134,21 +127,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -9,6 +9,7 @@ class LyricsRenderer extends StatefulWidget {
   final TextStyle chordStyle;
   final bool showChord;
   final Function onTapChord;
+  final ScrollController? scrollController;
 
   /// To help stop overflow, this should be the sum of left & right padding
   final int widgetPadding;
@@ -66,6 +67,7 @@ class LyricsRenderer extends StatefulWidget {
       this.scrollPhysics = const ClampingScrollPhysics(),
       this.leadingWidget,
       this.trailingWidget,
+      this.scrollController,
       this.chordNotation = ChordNotation.american})
       : super(key: key);
 
@@ -86,7 +88,7 @@ class _LyricsRendererState extends State<LyricsRenderer> {
         widget.textStyle.copyWith(fontWeight: FontWeight.bold);
     capoStyle = widget.capoStyle ??
         widget.textStyle.copyWith(fontStyle: FontStyle.italic);
-    _controller = ScrollController();
+    _controller = widget.scrollController ?? ScrollController();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // executes after build
       _scrollToEnd();
@@ -199,7 +201,8 @@ class _LyricsRendererState extends State<LyricsRenderer> {
     if (_controller.offset >= _controller.position.maxScrollExtent) return;
 
     final seconds =
-        (_controller.position.maxScrollExtent / (widget.scrollSpeed)).floor();
+        (_controller.positions.first.maxScrollExtent / (widget.scrollSpeed))
+            .floor();
 
     _controller.animateTo(
       _controller.position.maxScrollExtent,

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -8,7 +8,7 @@ class LyricsRenderer extends StatefulWidget {
   final TextStyle textStyle;
   final TextStyle chordStyle;
   final bool showChord;
-  final Function onTapChord;
+  final Function(String) onTapChord;
   final ScrollController? scrollController;
 
   /// To help stop overflow, this should be the sum of left & right padding

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -199,10 +199,11 @@ class _LyricsRendererState extends State<LyricsRenderer> {
     }
 
     if (_controller.offset >= _controller.position.maxScrollExtent) return;
-    
 
+    final extentToGo = _controller.position.maxScrollExtent - _controller.offset;
+    
     final seconds =
-        ((_controller.position.maxScrollExtent - _controller.offset) / (widget.scrollSpeed)).floor();
+        (extentToGo / (widget.scrollSpeed)).floor();
 
     _controller.animateTo(
       _controller.position.maxScrollExtent,

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -199,10 +199,10 @@ class _LyricsRendererState extends State<LyricsRenderer> {
     }
 
     if (_controller.offset >= _controller.position.maxScrollExtent) return;
+    
 
     final seconds =
-        (_controller.positions.first.maxScrollExtent / (widget.scrollSpeed))
-            .floor();
+        ((_controller.position.maxScrollExtent - _controller.offset) / (widget.scrollSpeed)).floor();
 
     _controller.animateTo(
       _controller.position.maxScrollExtent,

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -10,6 +10,8 @@ class LyricsRenderer extends StatefulWidget {
   final bool showChord;
   final Function(String) onTapChord;
   final ScrollController? scrollController;
+  final double topPadding;
+  final double bottomPadding;
 
   /// To help stop overflow, this should be the sum of left & right padding
   final int widgetPadding;
@@ -57,6 +59,8 @@ class LyricsRenderer extends StatefulWidget {
       required this.onTapChord,
       this.chorusStyle,
       this.capoStyle,
+      this.topPadding = 60,
+      this.bottomPadding = 100,
       this.scaleFactor = 1.0,
       this.showChord = true,
       this.widgetPadding = 0,
@@ -116,6 +120,11 @@ class _LyricsRendererState extends State<LyricsRenderer> {
     if (chordLyricsDocument.chordLyricsLines.isEmpty) return Container();
     return SingleChildScrollView(
       controller: _controller,
+      padding: EdgeInsets.only(
+          right: widget.widgetPadding.toDouble(),
+          left: widget.widgetPadding.toDouble(),
+          bottom: widget.bottomPadding,
+          top: widget.topPadding),
       physics: widget.scrollPhysics,
       child: Column(
         crossAxisAlignment: widget.horizontalAlignment,
@@ -200,10 +209,10 @@ class _LyricsRendererState extends State<LyricsRenderer> {
 
     if (_controller.offset >= _controller.position.maxScrollExtent) return;
 
-    final extentToGo = _controller.position.maxScrollExtent - _controller.offset;
-    
-    final seconds =
-        (extentToGo / (widget.scrollSpeed)).floor();
+    final extentToGo =
+        _controller.position.maxScrollExtent - _controller.offset;
+
+    final seconds = (extentToGo / (widget.scrollSpeed)).floor();
 
     _controller.animateTo(
       _controller.position.maxScrollExtent,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,14 +63,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   cli_util:
     dependency: transitive
     description:
@@ -84,7 +77,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -126,7 +119,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
@@ -171,21 +164,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -206,7 +199,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pub_semver:
     dependency: transitive
     description:
@@ -232,7 +225,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -253,21 +246,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
To give the dev more freedom to control the scroll screen I have allowed the use of a external ScrollController. It's not mandatory. If we get a null on the parameter, we use the same method as before.

I found a inconsistent behavior on the speed scroll. If I start the scroll from the top, a speed value give me a specific speed. But if I start the scroll in the midle or end of the music, then the same speed value give me a different speed.

Now same speed value allways give the same speed scrolling. What allow to create a consistent speed controller.