### PR TITLE
Fix chord overflow with custom breaks

### DIFF
--- a/lib/src/chord_parser.dart
+++ b/lib/src/chord_parser.dart
@@ -25,6 +25,7 @@ class ChordProcessor {
     double scaleFactor = 1.0,
     int widgetPadding = 0,
     int transposeIncrement = 0,
+    required List<String>? breakingCharacters,
   }) {
     final List<String> lines = text.split('\n');
     final MetadataHandler metadata = MetadataHandler();
@@ -50,7 +51,8 @@ class ChordProcessor {
             currentLine: currentLine,
             newLines: newLines,
             lyricsStyle: lyricsStyle,
-            widgetPadding: widgetPadding);
+            widgetPadding: widgetPadding,
+            breakingCharacters: breakingCharacters);
       } else {
         //otherwise just add the regular line
         newLines.add(currentLine.trim());
@@ -73,12 +75,15 @@ class ChordProcessor {
       {required List<String> newLines,
       required String currentLine,
       required TextStyle lyricsStyle,
-      required int widgetPadding}) {
+      required int widgetPadding,
+      List<String>? breakingCharacters}) {
     String _character = '';
     int _characterIndex = 0;
     String _currentCharacters = '';
     bool _chordHasStartedOuter = false;
     int _lastSpace = 0;
+    List<String> _breakCharacters =
+        breakingCharacters ?? [' ', ',', '.', '。', '、'];
 
     //print('found a big line $currentLine');
 
@@ -91,9 +96,9 @@ class ChordProcessor {
         _chordHasStartedOuter = false;
       } else if (!_chordHasStartedOuter) {
         _currentCharacters += _character;
-        if (_character == ' ') {
-          //use this marker to only split where there are spaces. We can trim later.
-          _lastSpace = j;
+        if (_breakCharacters.contains(_character)) {
+          //use this marker to only split where there are breaks. We can trim later.
+          _lastSpace = j + 1;
         }
 
         //This is the point where we need to split

--- a/lib/src/lyrics_renderer.dart
+++ b/lib/src/lyrics_renderer.dart
@@ -54,6 +54,9 @@ class LyricsRenderer extends StatefulWidget {
   /// Optional external scroll controller, otherwise will be created internally
   final ScrollController? scrollController;
 
+  /// List of characters that will break the line
+  final List<String>? breakingCharacters;
+
   const LyricsRenderer(
       {Key? key,
       required this.lyrics,
@@ -74,7 +77,8 @@ class LyricsRenderer extends StatefulWidget {
       this.leadingWidget,
       this.trailingWidget,
       this.chordNotation = ChordNotation.american,
-      this.scrollController})
+      this.scrollController,
+      this.breakingCharacters})
       : super(key: key);
 
   @override
@@ -136,6 +140,7 @@ class _LyricsRendererState extends State<LyricsRenderer> {
       widgetPadding: widget.widgetPadding,
       scaleFactor: widget.scaleFactor,
       transposeIncrement: widget.transposeIncrement,
+      breakingCharacters: widget.breakingCharacters,
     );
     if (chordLyricsDocument.chordLyricsLines.isEmpty) return Container();
     return SingleChildScrollView(


### PR DESCRIPTION
This addresses #11 

The idea is that users can add their own custom characters to break long lines for their language.  Note that this wouldn't work for languages without any breaking characters (Chinese, Thai).  

Before:
![Screenshot 2025-01-30 at 11 29 52 AM](https://github.com/user-attachments/assets/72b45ffe-9022-4a4b-9775-6a4b2455111e)

After:
![Screenshot 2025-01-30 at 11 30 14 AM](https://github.com/user-attachments/assets/d876486a-8ff7-4f8f-a3b6-39cc24fb9ed5)

